### PR TITLE
fix .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["es2015", {"modules": false}],
+    "es2015",
     "stage-1",
     "react"
   ],


### PR DESCRIPTION
# Overview
+ Stop tree shaking of Webpack
    + babel-node can not compile `import`...