### PR TITLE
Fix RouteMatcher initialization

### DIFF
--- a/src/lib/RouteMatcher.js
+++ b/src/lib/RouteMatcher.js
@@ -3,7 +3,7 @@ import Renderer from "./Renderer";
 
 class RouteMatcher {
   constructor() {
-    this.init()
+    this.init();
   }
 
   init() {

--- a/src/lib/RouteMatcher.js
+++ b/src/lib/RouteMatcher.js
@@ -3,9 +3,14 @@ import Renderer from "./Renderer";
 
 class RouteMatcher {
   constructor() {
+    this.init()
+  }
+
+  init() {
     this.routes = [];
     this.nameRoutes = {};
     this.renderer = null;
+    return this;
   }
 
   addRoute(path, component, name, isAsync) {

--- a/src/lib/Router.js
+++ b/src/lib/Router.js
@@ -65,6 +65,8 @@ export default class Router extends React.Component {
   }
 
   initRouteMatcher(routeMatcher, routes) {
+    routeMatcher.init();
+
     // Settings Routes.
     const normalizedRoutes = RouteNormalizer.make()
       .addRoutes(routes)

--- a/src/ssr/RouteResolver.js
+++ b/src/ssr/RouteResolver.js
@@ -9,7 +9,7 @@ export default class RouteResolver {
 
     this.routeMatcher = routeMatcher;
 
-    this.addRoute(route);
+    this.initRouteMatcher(route);
   }
 
   make(route) {
@@ -40,10 +40,9 @@ export default class RouteResolver {
       });
   }
 
-  /**
-   * Add route.
-   */
-  addRoute(route) {
+  initRouteMatcher(route) {
+    this.routeMatcher.init();
+
     const normalizedRoutes = RouteNormalizer.make()
       .addRoute(route)
       .get();


### PR DESCRIPTION
# Overview
+ Fix RouteMatcher initialization
    + RouteMatcher is changed to initialize because hot reloading at the time of development could not be performed